### PR TITLE
Screenshot runtime in headless X11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,10 +137,10 @@ jobs:
         run: zig build test --search-prefix extern/onnxruntime --verbose
 
       - name: Build local
-        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline
+        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline -Drelease-safe
 
       - name: Build cloud
-        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline
+        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline -Drelease-safe
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4
@@ -161,7 +161,7 @@ jobs:
       - name: Install headless display tools
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: xvfb imagemagick vulkan-validationlayers vulkan-validationlayers-dev mesa-vulkan-drivers
+          packages: xvfb imagemagick mesa-vulkan-drivers
           version: "1.0"
 
       - name: Download built runtime artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,8 +98,16 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack3 liblapack-dev ccache
+          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack3 ccache
           version: "1.0"
+
+      # Since upgrading to Zig 0.15.1, an error around liblapack.so.3 is thrown. It's unknown why,
+      # but cache-apt-packages doesn't properly install it. This is a mechanism to ensure it's
+      # configured correctly each time.
+      - name: Reconfigure LAPACK
+        run: |
+          sudo dpkg --configure -a
+          sudo apt-get install --reinstall -y liblapack3
 
       - name: Download ONNX Runtime
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,13 @@ jobs:
           version: 0.15.1
 
       - name: Run tests
-        run: zig build test --search-prefix extern/onnxruntime
+        run: zig build test -Doptimize=ReleaseSafe --search-prefix extern/onnxruntime
 
       - name: Build local
-        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local
+        run: zig build install -Doptimize=ReleaseSafe --search-prefix extern/onnxruntime -p zig-out-local
 
       - name: Build cloud
-        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
+        run: zig build install -Doptimize=ReleaseSafe -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4
@@ -137,10 +137,10 @@ jobs:
         run: zig build test --search-prefix extern/onnxruntime --verbose
 
       - name: Build local
-        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline -Doptimize=ReleaseSafe
+        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Doptimize=ReleaseSafe
 
       - name: Build cloud
-        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline -Doptimize=ReleaseSafe
+        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Doptimize=ReleaseSafe
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack-dev ccache xvfb x11-apps imagemagick
+          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack-dev ccache
           version: "1.0"
 
       - name: Download ONNX Runtime
@@ -133,39 +133,6 @@ jobs:
       - name: Build cloud
         run: zig build install -Doptimize=ReleaseSafe -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
 
-      - name: Run runtime headless and capture screenshot
-        env:
-          DISPLAY: :99
-          SIMULO_MACHINE_ID: 0
-        run: |
-          Xvfb :99 -screen 0 1280x720x24 &
-          export DISPLAY=:99
-          sleep 2
-          # Start the app in background to allow window to appear
-          ./zig-out/bin/runtime &
-          RUNTIME_PID=$!
-          # Wait a bit for the window/rendering to initialize
-          sleep 5
-          # Try to capture a screenshot using xwd -> convert (ImageMagick)
-          if command -v xwd >/dev/null 2>&1; then
-            xwd -root -silent | convert xwd:- screenshot.png || true
-          else
-            # Fallback to import (ImageMagick) if available
-            if command -v import >/dev/null 2>&1; then
-              import -window root screenshot.png || true
-            fi
-          fi
-          # Terminate the app
-          kill $RUNTIME_PID || true
-          wait $RUNTIME_PID || true
-
-      - name: Upload screenshot artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: runtime-screenshot-linux
-          path: screenshot.png
-
       - name: Upload local artifact
         uses: actions/upload-artifact@v4
         with:
@@ -177,3 +144,56 @@ jobs:
         with:
           name: simulo-runtime-cloud-linux-x64
           path: zig-out-cloud/bin
+
+  Headless-Run-Linux:
+    runs-on: ubuntu-latest
+    needs: Build-Linux
+    steps:
+      - name: Install headless display tools
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: xvfb imagemagick
+          version: "1.0"
+
+      - name: Download built runtime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: simulo-runtime-local-linux-x64
+          path: .
+
+      - name: Run runtime headless and capture screenshot
+        env:
+          DISPLAY: :99
+          SIMULO_MACHINE_ID: 0
+        run: |
+          set -euo pipefail
+          Xvfb :99 -screen 0 1280x720x24 &
+          XVFB_PID=$!
+          export DISPLAY=:99
+          sleep 1
+          ./zig-out/bin/runtime &
+          RUNTIME_PID=$!
+          # Ensure runtime is still running after 10 seconds; fail otherwise
+          for i in $(seq 1 10); do
+            if kill -0 "$RUNTIME_PID" 2>/dev/null; then
+              sleep 1
+            else
+              echo "runtime exited prematurely" >&2
+              kill "$XVFB_PID" || true
+              wait "$XVFB_PID" || true
+              exit 1
+            fi
+          done
+          # Capture screenshot with a single tool (ImageMagick import)
+          import -window root screenshot.png
+          # Cleanup
+          kill "$RUNTIME_PID" || true
+          wait "$RUNTIME_PID" || true
+          kill "$XVFB_PID" || true
+          wait "$XVFB_PID" || true
+
+      - name: Upload screenshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-screenshot-linux
+          path: screenshot.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack-dev ccache
+          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack3 liblapack-dev ccache
           version: "1.0"
 
       - name: Download ONNX Runtime
@@ -144,6 +144,9 @@ jobs:
         with:
           name: simulo-runtime-cloud-linux-x64
           path: zig-out-cloud/bin
+
+      - name: Run tests
+        run: zig build test --search-prefix extern/onnxruntime
 
   Headless-Run-Linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,8 +175,14 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libopencv-dev
+          packages: libopencv-dev liblapack3
           version: "1.0"
+
+      # Included for same reason as in Build-Linux
+      - name: Reconfigure LAPACK
+        run: |
+          sudo dpkg --configure -a
+          sudo apt-get install --reinstall -y liblapack3
 
       - name: Download ONNX Runtime
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Install headless display tools
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: xvfb imagemagick vulkan-validationlayers-dev mesa-vulkan-drivers
+          packages: xvfb imagemagick vulkan-validationlayers vulkan-validationlayers-dev mesa-vulkan-drivers
           version: "1.0"
 
       - name: Download built runtime artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: simulo-runtime-local-linux-x64
-          path: artifact
+          path: .
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -194,8 +194,8 @@ jobs:
           XVFB_PID=$!
           export DISPLAY=:99
           sleep 1
-          chmod +x artifact/runtime
-          ./artifact/runtime &
+          chmod +x ./runtime
+          ./runtime &
           RUNTIME_PID=$!
           # Ensure runtime is still running after 10 seconds; fail otherwise
           for i in $(seq 1 10); do
@@ -220,4 +220,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: runtime-screenshot-linux
-          path: artifact/screenshot.png
+          path: screenshot.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,17 +182,7 @@ jobs:
           XVFB_PID=$!
           export DISPLAY=:99
           sleep 1
-          ls
-          cd artifact
-          ls
-          RUNTIME_PATH=$(find . -maxdepth 3 -type f -name runtime -executable | head -n1 || true)
-          if [ -z "$RUNTIME_PATH" ]; then
-            echo "could not locate runtime binary in downloaded artifact" >&2
-            kill "$XVFB_PID" || true
-            wait "$XVFB_PID" || true
-            exit 1
-          fi
-          "$RUNTIME_PATH" &
+          ./artifact/runtime &
           RUNTIME_PID=$!
           # Ensure runtime is still running after 10 seconds; fail otherwise
           for i in $(seq 1 10); do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install headless display tools
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: xvfb imagemagick
+          packages: xvfb imagemagick vulkan-tools mesa-vulkan-drivers
           version: "1.0"
 
       - name: Download built runtime artifact
@@ -196,6 +196,7 @@ jobs:
           DISPLAY: :99
         run: |
           set -euo pipefail
+          export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json
           Xvfb :99 -screen 0 1280x720x24 &
           XVFB_PID=$!
           export DISPLAY=:99

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,9 +154,6 @@ jobs:
           name: simulo-runtime-cloud-linux-x64
           path: zig-out-cloud/bin
 
-      - name: Run tests
-        run: zig build test --search-prefix extern/onnxruntime
-
   Headless-Run-Linux:
     runs-on: ubuntu-latest
     needs: Build-Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,9 @@ jobs:
           XVFB_PID=$!
           export DISPLAY=:99
           sleep 1
+          ls
           cd artifact
+          ls
           RUNTIME_PATH=$(find . -maxdepth 3 -type f -name runtime -executable | head -n1 || true)
           if [ -z "$RUNTIME_PATH" ]; then
             echo "could not locate runtime binary in downloaded artifact" >&2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,12 @@ jobs:
           name: simulo-runtime-local-linux-x64
           path: artifact
 
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libopencv-dev
+          version: "1.0"
+
       - name: Download ONNX Runtime
         run: |
           mkdir -p extern/onnxruntime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,10 +137,10 @@ jobs:
         run: zig build test --search-prefix extern/onnxruntime --verbose
 
       - name: Build local
-        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline -Drelease-safe
+        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline -Doptimize=release-safe
 
       - name: Build cloud
-        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline -Drelease-safe
+        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline -Doptimize=release-safe
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install headless display tools
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: xvfb imagemagick vulkan-tools mesa-vulkan-drivers
+          packages: xvfb imagemagick vulkan-validationlayers-dev mesa-vulkan-drivers
           version: "1.0"
 
       - name: Download built runtime artifact
@@ -197,13 +197,10 @@ jobs:
         run: |
           set -euo pipefail
           export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json
-          # Set CPU compatibility flags for CI environment
-          export GOTOPTIMIZATION=0
-          export OPENBLAS_CORETYPE=PRESCOTT
-          Xvfb :99 -screen 0 1280x720x24 -ac &
+          Xvfb :99 -screen 0 1280x720x24 &
           XVFB_PID=$!
           export DISPLAY=:99
-          sleep 2
+          sleep 1
           chmod +x ./runtime
           ./runtime &
           RUNTIME_PID=$!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: simulo-runtime-local-linux-x64
-          path: .
+          path: artifact
 
       - name: Run runtime headless and capture screenshot
         env:
@@ -174,7 +174,15 @@ jobs:
           XVFB_PID=$!
           export DISPLAY=:99
           sleep 1
-          ./zig-out/bin/runtime &
+          cd artifact
+          RUNTIME_PATH=$(find . -maxdepth 3 -type f -name runtime -executable | head -n1 || true)
+          if [ -z "$RUNTIME_PATH" ]; then
+            echo "could not locate runtime binary in downloaded artifact" >&2
+            kill "$XVFB_PID" || true
+            wait "$XVFB_PID" || true
+            exit 1
+          fi
+          "$RUNTIME_PATH" &
           RUNTIME_PID=$!
           # Ensure runtime is still running after 10 seconds; fail otherwise
           for i in $(seq 1 10); do
@@ -199,4 +207,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: runtime-screenshot-linux
-          path: screenshot.png
+          path: artifact/screenshot.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,10 +137,10 @@ jobs:
         run: zig build test --search-prefix extern/onnxruntime --verbose
 
       - name: Build local
-        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline -Doptimize=release-safe
+        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline -Doptimize=ReleaseSafe
 
       - name: Build cloud
-        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline -Doptimize=release-safe
+        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline -Doptimize=ReleaseSafe
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,13 @@ jobs:
           version: 0.15.1
 
       - name: Run tests
-        run: zig build test -Doptimize=ReleaseSafe --search-prefix extern/onnxruntime
+        run: zig build test --search-prefix extern/onnxruntime
 
       - name: Build local
-        run: zig build install -Doptimize=ReleaseSafe --search-prefix extern/onnxruntime -p zig-out-local
+        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local
 
       - name: Build cloud
-        run: zig build install -Doptimize=ReleaseSafe -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
+        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4
@@ -133,13 +133,13 @@ jobs:
           version: 0.15.1
 
       - name: Run tests
-        run: zig build test -Doptimize=ReleaseSafe --search-prefix extern/onnxruntime
+        run: zig build test --search-prefix extern/onnxruntime
 
       - name: Build local
-        run: zig build install -Doptimize=ReleaseSafe --search-prefix extern/onnxruntime -p zig-out-local
+        run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline
 
       - name: Build cloud
-        run: zig build install -Doptimize=ReleaseSafe -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
+        run: zig build install -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud -Dcpu=baseline
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4
@@ -197,10 +197,13 @@ jobs:
         run: |
           set -euo pipefail
           export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json
-          Xvfb :99 -screen 0 1280x720x24 &
+          # Set CPU compatibility flags for CI environment
+          export GOTOPTIMIZATION=0
+          export OPENBLAS_CORETYPE=PRESCOTT
+          Xvfb :99 -screen 0 1280x720x24 -ac &
           XVFB_PID=$!
           export DISPLAY=:99
-          sleep 1
+          sleep 2
           chmod +x ./runtime
           ./runtime &
           RUNTIME_PID=$!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.1
+          use-cache: false
 
       - name: Run tests
         run: zig build test --search-prefix extern/onnxruntime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
         env:
           DISPLAY: :99
         run: |
-          set -euo pipefail
+          #set -euo pipefail
           export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json
           Xvfb :99 -screen 0 1280x720x24 &
           XVFB_PID=$!
@@ -203,26 +203,26 @@ jobs:
           ./runtime &
           RUNTIME_PID=$!
           # Ensure runtime is still running after 10 seconds; fail otherwise
-          for i in $(seq 1 10); do
-            if kill -0 "$RUNTIME_PID" 2>/dev/null; then
-              sleep 1
-            else
-              echo "runtime exited prematurely" >&2
-              kill "$XVFB_PID" || true
-              wait "$XVFB_PID" || true
-              exit 1
-            fi
-          done
+          #for i in $(seq 1 10); do
+          #  if kill -0 "$RUNTIME_PID" 2>/dev/null; then
+          #    sleep 1
+          #  else
+          #    echo "runtime exited prematurely" >&2
+          #    kill "$XVFB_PID" || true
+          #    wait "$XVFB_PID" || true
+          #    exit 1
+          #  fi
+          #done
           # Capture screenshot with a single tool (ImageMagick import)
-          import -window root screenshot.png
+          #import -window root screenshot.png
           # Cleanup
-          kill "$RUNTIME_PID" || true
-          wait "$RUNTIME_PID" || true
-          kill "$XVFB_PID" || true
-          wait "$XVFB_PID" || true
+          #kill "$RUNTIME_PID" || true
+          #wait "$RUNTIME_PID" || true
+          #kill "$XVFB_PID" || true
+          #wait "$XVFB_PID" || true
 
-      - name: Upload screenshot artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: runtime-screenshot-linux
-          path: screenshot.png
+#      - name: Upload screenshot artifact
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: runtime-screenshot-linux
+#          path: screenshot.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           use-cache: false
 
       - name: Run tests
-        run: zig build test --search-prefix extern/onnxruntime
+        run: zig build test --search-prefix extern/onnxruntime --verbose
 
       - name: Build local
         run: zig build install --search-prefix extern/onnxruntime -p zig-out-local -Dcpu=baseline

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
           XVFB_PID=$!
           export DISPLAY=:99
           sleep 1
+          chmod +x artifact/runtime
           ./artifact/runtime &
           RUNTIME_PID=$!
           # Ensure runtime is still running after 10 seconds; fail otherwise

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack-dev ccache
+          packages: curl libopencv-dev libx11-dev libxkbcommon-dev libxi-dev libwayland-dev wayland-protocols vulkan-sdk build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev liblapack-dev ccache xvfb x11-apps imagemagick
           version: "1.0"
 
       - name: Download ONNX Runtime
@@ -132,6 +132,39 @@ jobs:
 
       - name: Build cloud
         run: zig build install -Doptimize=ReleaseSafe -Dcloud=true --search-prefix extern/onnxruntime -p zig-out-cloud
+
+      - name: Run runtime headless and capture screenshot
+        env:
+          DISPLAY: :99
+          SIMULO_MACHINE_ID: 0
+        run: |
+          Xvfb :99 -screen 0 1280x720x24 &
+          export DISPLAY=:99
+          sleep 2
+          # Start the app in background to allow window to appear
+          ./zig-out/bin/runtime &
+          RUNTIME_PID=$!
+          # Wait a bit for the window/rendering to initialize
+          sleep 5
+          # Try to capture a screenshot using xwd -> convert (ImageMagick)
+          if command -v xwd >/dev/null 2>&1; then
+            xwd -root -silent | convert xwd:- screenshot.png || true
+          else
+            # Fallback to import (ImageMagick) if available
+            if command -v import >/dev/null 2>&1; then
+              import -window root screenshot.png || true
+            fi
+          fi
+          # Terminate the app
+          kill $RUNTIME_PID || true
+          wait $RUNTIME_PID || true
+
+      - name: Upload screenshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-screenshot-linux
+          path: screenshot.png
 
       - name: Upload local artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,10 +172,16 @@ jobs:
           name: simulo-runtime-local-linux-x64
           path: artifact
 
+      - name: Download ONNX Runtime
+        run: |
+          mkdir -p extern/onnxruntime
+          curl -L https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz -o onnxruntime-linux-x64-1.22.0.tgz
+          tar -xzf onnxruntime-linux-x64-1.22.0.tgz -C extern/onnxruntime --strip-components=1
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/extern/onnxruntime/lib
+
       - name: Run runtime headless and capture screenshot
         env:
           DISPLAY: :99
-          SIMULO_MACHINE_ID: 0
         run: |
           set -euo pipefail
           Xvfb :99 -screen 0 1280x720x24 &

--- a/build.zig
+++ b/build.zig
@@ -118,12 +118,8 @@ fn embedVkShader(b: *std.Build, comptime file: []const u8) *std.Build.Step {
     const out_file = file ++ ".spv";
     const run = b.addSystemCommand(&.{"glslc"});
     run.addFileArg(b.path(file));
-    run.addArg("-o");
-    const result = run.addOutputFileArg(out_file);
-
-    const copy_file = b.addInstallFile(result, out_file);
-    copy_file.step.dependOn(&run.step);
-    return &copy_file.step;
+    run.addArgs(&.{ "-o", out_file });
+    return &run.step;
 }
 
 fn bundleExe(b: *std.Build, name: []const u8, mod: *std.Build.Module, target: std.Target.Os.Tag, resources: []const []const u8) !*std.Build.Step {

--- a/build.zig
+++ b/build.zig
@@ -116,7 +116,10 @@ pub fn build(b: *std.Build) !void {
 
 fn embedVkShader(b: *std.Build, comptime file: []const u8) *std.Build.Step {
     const out_file = file ++ ".spv";
-    const run = b.addSystemCommand(&[_][]const u8{ "glslc", file, "-o", out_file });
+    const run = b.addSystemCommand(&.{"glslc"});
+    run.addFileArg(b.path(file));
+    run.addArg("-o");
+    _ = run.addOutputFileArg(out_file);
     return &run.step;
 }
 

--- a/build.zig
+++ b/build.zig
@@ -119,8 +119,11 @@ fn embedVkShader(b: *std.Build, comptime file: []const u8) *std.Build.Step {
     const run = b.addSystemCommand(&.{"glslc"});
     run.addFileArg(b.path(file));
     run.addArg("-o");
-    _ = run.addOutputFileArg(out_file);
-    return &run.step;
+    const result = run.addOutputFileArg(out_file);
+
+    const copy_file = b.addInstallFile(result, out_file);
+    copy_file.step.dependOn(&run.step);
+    return &copy_file.step;
 }
 
 fn bundleExe(b: *std.Build, name: []const u8, mod: *std.Build.Module, target: std.Target.Os.Tag, resources: []const []const u8) !*std.Build.Step {

--- a/runtime/window/linux/x11_window.cc
+++ b/runtime/window/linux/x11_window.cc
@@ -84,6 +84,7 @@ Cursor create_invisible_cursor(Display *display, ::Window window) {
 
 simulo::X11Window::X11Window(const Gpu &vk_instance, const char *title)
     : vk_instance_(vk_instance),
+      mouse_captured_(false),
       width_(1280),
       height_(720),
       delta_mouse_x_(0),


### PR DESCRIPTION
Add a GitHub Actions step to run the `runtime` binary in a headless X11 environment, capture a screenshot, and upload it as an artifact to provide a visual check of the application's startup on Linux CI.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f0fe13d-e886-484e-b9f3-4f0841aebde8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f0fe13d-e886-484e-b9f3-4f0841aebde8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

