### PR TITLE
Centralize private key reading to remote.zig

### DIFF
--- a/runtime/main.zig
+++ b/runtime/main.zig
@@ -21,26 +21,11 @@ pub fn main() !void {
         return;
     };
 
-    const machine_id = std.process.getEnvVarOwned(allocator, "SIMULO_MACHINE_ID") catch |err| {
-        switch (err) {
-            error.EnvironmentVariableNotFound => {
-                std.log.err("error: SIMULO_MACHINE_ID is not set", .{});
-                return;
-            },
-            error.OutOfMemory => util.crash.oom(error.OutOfMemory),
-            else => {
-                std.log.err("error: failed to get SIMULO_MACHINE_ID: {any}", .{err});
-                return;
-            },
-        }
-    };
-    defer allocator.free(machine_id);
-
     try Runtime.globalInit();
     defer Runtime.globalDeinit();
 
     var runtime: Runtime = undefined;
-    try Runtime.init(&runtime, machine_id, allocator);
+    try Runtime.init(&runtime, allocator);
     defer runtime.deinit();
 
     try runtime.run();

--- a/runtime/remote/noop_remote.zig
+++ b/runtime/remote/noop_remote.zig
@@ -5,7 +5,7 @@ const Packet = packet.Packet;
 pub const NoOpRemote = struct {
     allocator: std.mem.Allocator,
 
-    pub fn init(allocator: std.mem.Allocator, _: []const u8, _: *const [32]u8) !NoOpRemote {
+    pub fn init(allocator: std.mem.Allocator, _: []const u8) !NoOpRemote {
         return NoOpRemote{
             .allocator = allocator,
         };

--- a/runtime/remote/noop_remote.zig
+++ b/runtime/remote/noop_remote.zig
@@ -5,7 +5,7 @@ const Packet = packet.Packet;
 pub const NoOpRemote = struct {
     allocator: std.mem.Allocator,
 
-    pub fn init(allocator: std.mem.Allocator, _: []const u8) !NoOpRemote {
+    pub fn init(allocator: std.mem.Allocator) !NoOpRemote {
         return NoOpRemote{
             .allocator = allocator,
         };

--- a/runtime/remote/remote.zig
+++ b/runtime/remote/remote.zig
@@ -19,6 +19,23 @@ fn apiHost() []const u8 {
     return std.mem.trimStart(u8, noHttps, "http://");
 }
 
+const fs_storage = @import("../fs_storage.zig");
+
+fn readPrivateKey() ![32]u8 {
+    var private_key_path_buf: [512]u8 = undefined;
+    const private_key_path = fs_storage.getFilePath(&private_key_path_buf, "private.der") catch unreachable;
+
+    var private_key_buf: [68]u8 = undefined;
+    const private_key_der = try std.fs.cwd().readFile(private_key_path, &private_key_buf);
+    if (private_key_der.len < 48) {
+        return error.PrivateKeyTooShort;
+    }
+
+    var private_key: [32]u8 = undefined;
+    @memcpy(&private_key, private_key_der[private_key_der.len - 32 ..]);
+    return private_key;
+}
+
 pub const Remote = struct {
     allocator: std.mem.Allocator,
     id: []const u8,
@@ -30,16 +47,13 @@ pub const Remote = struct {
     reconnect_delay_ms: u64 = MIN_RECONNECT_DELAY_MS,
     inbound_queue: Spsc(Packet, 128),
 
-    pub fn init(allocator: std.mem.Allocator, id: []const u8, private_key: *const [32]u8) !Remote {
+    pub fn init(allocator: std.mem.Allocator, id: []const u8) !Remote {
         if (id.len > 64) {
             return error.InvalidId;
         }
 
-        if (private_key.len != 32) {
-            return error.InvalidPrivateKey;
-        }
-
-        const key_pair = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic(private_key.*);
+        const private_key = try readPrivateKey();
+        const key_pair = try std.crypto.sign.Ed25519.KeyPair.generateDeterministic(private_key);
 
         return Remote{
             .allocator = allocator,

--- a/runtime/remote/remote.zig
+++ b/runtime/remote/remote.zig
@@ -38,7 +38,7 @@ fn readPrivateKey() ![32]u8 {
 
 pub const Remote = struct {
     allocator: std.mem.Allocator,
-    id: []u8,
+    id: []const u8,
     secret_key: std.crypto.sign.Ed25519.KeyPair,
 
     read_thread: ?std.Thread = null,
@@ -68,8 +68,6 @@ pub const Remote = struct {
 
     pub fn deinit(self: *Remote) void {
         @atomicStore(bool, &self.running, false, .seq_cst);
-
-        self.allocator.free(self.id);
 
         if (self.read_thread) |*thread| {
             thread.join();

--- a/runtime/runtime.zig
+++ b/runtime/runtime.zig
@@ -113,9 +113,9 @@ pub const Runtime = struct {
         Wasm.globalDeinit();
     }
 
-    pub fn init(runtime: *Runtime, machine_id: []const u8, allocator: std.mem.Allocator) !void {
+    pub fn init(runtime: *Runtime, allocator: std.mem.Allocator) !void {
         runtime.allocator = allocator;
-        runtime.remote = try Remote.init(allocator, machine_id);
+        runtime.remote = try Remote.init(allocator);
         errdefer runtime.remote.deinit();
         try runtime.remote.start();
 

--- a/runtime/runtime.zig
+++ b/runtime/runtime.zig
@@ -113,9 +113,9 @@ pub const Runtime = struct {
         Wasm.globalDeinit();
     }
 
-    pub fn init(runtime: *Runtime, machine_id: []const u8, private_key: *const [32]u8, allocator: std.mem.Allocator) !void {
+    pub fn init(runtime: *Runtime, machine_id: []const u8, allocator: std.mem.Allocator) !void {
         runtime.allocator = allocator;
-        runtime.remote = try Remote.init(allocator, machine_id, private_key);
+        runtime.remote = try Remote.init(allocator, machine_id);
         errdefer runtime.remote.deinit();
         try runtime.remote.start();
 


### PR DESCRIPTION
Move private key reading to `remote.zig` and remove private key parameters from `Remote` and `NoOpRemote` initializers to centralize key handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-c24caa27-97dc-4ed3-9c0c-c56ae482a3de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c24caa27-97dc-4ed3-9c0c-c56ae482a3de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

