### PR TITLE
Update cloud flag and runtime logic

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,13 +12,13 @@ pub fn build(b: *std.Build) !void {
     const custom_api_url = b.option([]const u8, "api_url", "Override API URL") orelse "https://api.simulo.tech";
     const wasm_path = b.option([]const u8, "wasm_path", "Override path to read WASM binary from");
     const new_wasm = b.option(bool, "new_wasm", "Use the experimental WASM JIT compiler") orelse false;
-    const local_dev = b.option(bool, "local_dev", "Compile for local development mode") orelse false;
+    const cloud = b.option(bool, "cloud", "Enable cloud connectivity") orelse false;
 
     const options = b.addOptions();
     options.addOption([]const u8, "api_url", custom_api_url);
     options.addOption(?[]const u8, "wasm_path", wasm_path);
     options.addOption(bool, "new_wasm", new_wasm);
-    options.addOption(bool, "local_dev", local_dev);
+    options.addOption(bool, "cloud", cloud);
 
     const util = b.createModule(.{
         .root_source_file = b.path("util/util.zig"),

--- a/runtime/runtime.zig
+++ b/runtime/runtime.zig
@@ -12,10 +12,10 @@ const fs_storage = @import("fs_storage.zig");
 const pose = @import("inference/pose.zig");
 pub const PoseDetector = pose.PoseDetector;
 
-pub const Remote = if (build_options.local_dev)
-    @import("remote/noop_remote.zig").NoOpRemote
+pub const Remote = if (build_options.cloud)
+    @import("remote/remote.zig").Remote
 else
-    @import("remote/remote.zig").Remote;
+    @import("remote/noop_remote.zig").NoOpRemote;
 
 pub const Renderer = @import("render/renderer.zig").Renderer;
 pub const Window = @import("window/window.zig").Window;


### PR DESCRIPTION
Rename `local_dev` build flag to `cloud` and invert its condition in `runtime.zig` for clearer logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4c30118-ac71-4ca7-80dc-7488725c0b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4c30118-ac71-4ca7-80dc-7488725c0b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

