### PR TITLE
Add render layer to wasm object creation

### DIFF
--- a/example/main.cc
+++ b/example/main.cc
@@ -2,7 +2,7 @@
 
 class Particle : public RenderedObject {
 public:
-   Particle(glm::vec2 position, const Material &material) : RenderedObject(material) {
+   Particle(glm::vec2 position, const Material &material, uint32_t layer) : RenderedObject(material, layer) {
       this->position = position;
       scale = glm::vec2(10.0f, 10.0f);
       transform_outdated();
@@ -33,7 +33,8 @@ public:
          float offset = i * 10.0f;
          float scale_offset = i / 2.0f;
          glm::vec2 position = glm::vec2(simulo_window_width() / 2 + offset, simulo_window_height() / 2 + offset);
-         auto particle = std::make_unique<Particle>(position, particle_material);
+         uint32_t layer = static_cast<uint32_t>((i + 2) % 4);
+         auto particle = std::make_unique<Particle>(position, particle_material, layer);
          particle->scale += scale_offset;
          add_child(std::unique_ptr<Particle>(std::move(particle)));
       }

--- a/example/simulo__pre.h
+++ b/example/simulo__pre.h
@@ -42,7 +42,7 @@ __attribute__((__import_name__("simulo_drop_object")))
 extern void simulo_drop_object(uint32_t);
 
 __attribute__((__import_name__("simulo_create_rendered_object")))
-extern uint32_t simulo_create_rendered_object(uint32_t material);
+extern uint32_t simulo_create_rendered_object(uint32_t material, uint32_t layer);
 
 __attribute__((__import_name__("simulo_set_rendered_object_material")))
 extern void simulo_set_rendered_object_material(uint32_t id, uint32_t material);
@@ -220,7 +220,7 @@ private:
 
 class RenderedObject : public Object {
 public:
-   RenderedObject(const Material &material) : Object(), simulo__render_id(simulo_create_rendered_object(material.simulo__id)) {
+   RenderedObject(const Material &material, uint32_t layer = 0) : Object(), simulo__render_id(simulo_create_rendered_object(material.simulo__id, layer)) {
       transform_outdated();
    }
 

--- a/runtime/runtime.zig
+++ b/runtime/runtime.zig
@@ -598,9 +598,10 @@ pub const Runtime = struct {
         runtime.markOutdatedTransform(@intCast(id));
     }
 
-    fn wasmCreateRenderedObject(env: *Wasm, material_id: u32) u32 {
+    fn wasmCreateRenderedObject(env: *Wasm, material_id: u32, layer: u32) u32 {
         const runtime: *Runtime = @alignCast(@fieldParentPtr("wasm", env));
-        const obj = runtime.renderer.addObject(runtime.mesh, Mat4.identity(), .{ .id = material_id }, 0) catch |err| util.crash.oom(err);
+        const clamped_layer: u8 = @intCast(@min(layer, 15));
+        const obj = runtime.renderer.addObject(runtime.mesh, Mat4.identity(), .{ .id = material_id }, clamped_layer) catch |err| util.crash.oom(err);
         return obj.id;
     }
 


### PR DESCRIPTION
Add a `layer` parameter to the WASM `create_rendered_object` function to specify the render layer (0-15).

---
<a href="https://cursor.com/background-agent?bcId=bc-30580159-21c9-4f34-95bb-8edf316e01a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30580159-21c9-4f34-95bb-8edf316e01a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

