### PR TITLE
Optimize remote message parsing with arena allocator

### DIFF
--- a/runtime/runtime.zig
+++ b/runtime/runtime.zig
@@ -350,7 +350,7 @@ pub const Runtime = struct {
 
             while (self.remote.nextMessage()) |msg| {
                 var message = msg;
-                defer message.deinit(self.allocator);
+                defer message.deinit();
 
                 switch (message) {
                     .download => |download| {


### PR DESCRIPTION
Refactor Remote message parsing to use a per-message ArenaAllocator for efficient allocation and deallocation of message fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-90ee091b-7fdc-4d72-b183-4e5f48775248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90ee091b-7fdc-4d72-b183-4e5f48775248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

